### PR TITLE
Merge json error

### DIFF
--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -1,6 +1,8 @@
 import logging
-
 import requests
+import simplejson
+
+from time import sleep
 
 API_URL = "https://home.nest.com"
 CAMERA_WEBAPI_BASE = "https://webapi.camera.home.nest.com"
@@ -201,6 +203,17 @@ class NestAPI():
                 sensor_data["location"]
             self.device_data[camera]['data_tier'] = \
                 sensor_data["properties"]["streaming.data-usage-tier"]
+        except simplejson.errors.JSONDecodeError as e:
+            _LOGGER.error(e)
+            if r.status_code != 200 and r.status_code != 502:
+                _LOGGER.error('Information for further debugging: ' +
+                             'return code {} '.format(r.status_code) +
+                             'and returned text {}'.format(r.text))
+
+            if r.status_code == 502:
+                _LOGGER.error('Error 502, Failed to update, retrying in 30s')
+                sleep(30)
+                self.update_camera(camera)
         except requests.exceptions.RequestException as e:
             _LOGGER.error(e)
             _LOGGER.error('Failed to update, trying again')
@@ -334,10 +347,23 @@ class NestAPI():
                         sensor_data['current_temperature']
                     self.device_data[sn]['battery_level'] = \
                         sensor_data['battery_level']
+        except simplejson.errors.JSONDecodeError as e:
+            _LOGGER.error(e)
+            if r.status_code != 200 and r.status_code != 502:
+                _LOGGER.error('Information for further debugging: ' +
+                             'return code {} '.format(r.status_code) +
+                             'and returned text {}'.format(r.text))
+
+            if r.status_code == 502:
+                _LOGGER.error('Error 502, Failed to update, retrying in 30s')
+                sleep(30)
+                self.update()
+        
         except requests.exceptions.RequestException as e:
             _LOGGER.error(e)
-            _LOGGER.error("Failed to update, trying again")
+            _LOGGER.error('Failed to update, trying again')
             self.update()
+            
         except KeyError:
             _LOGGER.debug("Failed to update, trying to log in again")
             self.login()


### PR DESCRIPTION
From: https://github.com/badguy99/badnest/tree/json_error

When the JSON error was being seen, the requests post (r = self._session.post)
was getting a 502 response with the following text:

<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>

added code to catch the exception, retry after 30 seconds if a 502 status code
was return to requests. Also added extra debugging if other status codes were
returned.

With the fix, I now get the following, rather than exception and traceback in my logs:

2020-05-09 21:03:30 ERROR (SyncWorker_9) [custom_components.badnest.api] Expecting value: line 1 column 1 (char 0)
2020-05-09 21:03:31 ERROR (SyncWorker_9) [custom_components.badnest.api] Error 502, Failed to update, retrying in 30s
2020-05-09 21:03:37 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.downstairs_protect_co_status is taking over 10 seconds
2020-05-09 21:03:51 WARNING (MainThread) [homeassistant.components.sensor] Updating badnest sensor took longer than the scheduled update interval 0:00:30

fixes: #88